### PR TITLE
#30 [layout] 보관함 격자 배경 사이즈 조절 및 카드 모서리 튀어나온 부분 해결

### DIFF
--- a/app/src/main/res/layout/fragment_storage.xml
+++ b/app/src/main/res/layout/fragment_storage.xml
@@ -16,15 +16,16 @@
         android:id="@+id/constraintLayout_storage_out"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@drawable/bg_home_for_white"
         tools:context=".ui.storage.StorageFragment">
 
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:src="@drawable/bg_linegrid_for_white"
-            tools:layout_editor_absoluteX="0dp"
-            tools:layout_editor_absoluteY="0dp" />
+        <View
+            android:layout_width="0dp"
+            android:layout_height="60dp"
+            android:background="@color/spark_white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -40,7 +41,7 @@
                 android:id="@+id/tv_storage_title_nickname"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:fontFamily="@font/futura_medium"
+                android:fontFamily="@font/noto_sans_kr_medium"
                 android:includeFontPadding="false"
                 android:text="나는야쿵짝지혜 님의"
                 android:textAlignment="viewStart"
@@ -53,16 +54,13 @@
                 android:id="@+id/tv_storage_title_sparkNumber"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:fontFamily="@font/futura_medium"
+                android:fontFamily="@font/noto_sans_kr_medium"
                 android:includeFontPadding="false"
                 android:text="19가지 스파크"
-                app:layout_constraintStart_toStartOf="@+id/tv_storage_title_nickname"
-                app:layout_constraintTop_toBottomOf="@id/tv_storage_title_nickname"
-                android:textSize="20dp"
                 android:textColor="@color/spark_black"
-
-
-                />
+                android:textSize="20dp"
+                app:layout_constraintStart_toStartOf="@+id/tv_storage_title_nickname"
+                app:layout_constraintTop_toBottomOf="@id/tv_storage_title_nickname" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -169,10 +167,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
-            app:layout_constraintStart_toEndOf="@id/constraintLayout_complete_touchArea"
-            app:layout_constraintTop_toTopOf="@id/constraintLayout_progressing_touchArea"
             android:onClick="@{()->storageViewModel.initIncompleteMode()}"
-            >
+            app:layout_constraintStart_toEndOf="@id/constraintLayout_complete_touchArea"
+            app:layout_constraintTop_toTopOf="@id/constraintLayout_progressing_touchArea">
 
             <View
                 android:id="@+id/view_storage_incomplete_indicator"


### PR DESCRIPTION
## 관련 이슈번호
#30 
## 화면 이름
	 보관함 
## 완료 태스크
- [ ] 격자 사이즈 조절
- [ ] 카드 하단 모서리 튀어나옴 해결