### PR TITLE
#126 [대기방] 새로고침 중복터치 막기

### DIFF
--- a/app/src/main/java/com/spark/android/ui/waitingroom/WaitingRoomFragment.kt
+++ b/app/src/main/java/com/spark/android/ui/waitingroom/WaitingRoomFragment.kt
@@ -165,6 +165,10 @@ class WaitingRoomFragment :
     private fun initRefreshButtonListener() {
         binding.btnWaitingRoomRefresh.setOnClickListener {
             FloatingAnimationUtil.rotateAnimation(binding.btnWaitingRoomRefresh)
+            binding.btnWaitingRoomRefresh.isEnabled = false
+            Handler(Looper.getMainLooper()).postDelayed({
+                binding.btnWaitingRoomRefresh.isEnabled = true
+            }, FloatingAnimationUtil.ROTATE_TIME)
             waitingRoomViewModel.getRefreshInfo(roomId)
             waitingRoomViewModel.refreshInfo.observe(this) {
                 waitingRoomRecyclerViewAdapter.members.clear()

--- a/app/src/main/java/com/spark/android/util/FloatingAnimationUtil.kt
+++ b/app/src/main/java/com/spark/android/util/FloatingAnimationUtil.kt
@@ -13,6 +13,8 @@ import java.util.logging.Handler
 
 object FloatingAnimationUtil {
 
+    const val ROTATE_TIME :Long = 1500
+
     fun toggleFab(
         buttonMain: FloatingActionButton,
         buttonMakeRoom: FloatingActionButton,
@@ -87,8 +89,8 @@ object FloatingAnimationUtil {
     fun rotateAnimation(
         imageButton: ImageButton
     ) {
-        ObjectAnimator.ofFloat(imageButton, View.ROTATION, -360f, 0f).apply {
-            duration = 2000
+        ObjectAnimator.ofFloat(imageButton, View.ROTATION, 360f, 0f).apply {
+            duration = ROTATE_TIME
             start()
         }
     }


### PR DESCRIPTION
## 관련 이슈번호
#126 
## 화면 이름
대기방
## 완료 태스크
- [x] 새로고침 버튼 중복터치 막기 (추후에 애니메이터 리스너로 리펙토링 필요)
