### PR TITLE
#145 [로그인,회원가입] 회원여부 판별 서버 연결

### DIFF
--- a/app/src/main/java/com/spark/android/data/remote/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/spark/android/data/remote/datasource/AuthDataSource.kt
@@ -1,6 +1,7 @@
 package com.spark.android.data.remote.datasource
 
 import com.spark.android.data.remote.entity.response.BaseResponse
+import com.spark.android.data.remote.entity.response.DoorbellResponse
 import com.spark.android.data.remote.entity.response.SignUpResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -10,4 +11,6 @@ interface AuthDataSource {
         map: Map<String, RequestBody>,
         profileImg: MultipartBody.Part?
     ): BaseResponse<SignUpResponse>
+
+    suspend fun getAccessToken(socialId: String, fcmToken: String): BaseResponse<DoorbellResponse>
 }

--- a/app/src/main/java/com/spark/android/data/remote/datasource/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/spark/android/data/remote/datasource/AuthDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.spark.android.data.remote.datasource
 
 import com.spark.android.data.remote.entity.response.BaseResponse
+import com.spark.android.data.remote.entity.response.DoorbellResponse
 import com.spark.android.data.remote.entity.response.SignUpResponse
 import com.spark.android.data.remote.service.AuthService
 import okhttp3.MultipartBody
@@ -20,4 +21,10 @@ class AuthDataSourceImpl @Inject constructor(
             authService.postSignUpWithImg(map, profileImg)
         }
     }
+
+    override suspend fun getAccessToken(
+        socialId: String,
+        fcmToken: String
+    ): BaseResponse<DoorbellResponse> =
+        authService.getAccessToken(socialId, fcmToken)
 }

--- a/app/src/main/java/com/spark/android/data/remote/entity/response/DoorbellResponse.kt
+++ b/app/src/main/java/com/spark/android/data/remote/entity/response/DoorbellResponse.kt
@@ -1,0 +1,6 @@
+package com.spark.android.data.remote.entity.response
+
+data class DoorbellResponse(
+    val accesstoken: String,
+    val isNew: Boolean
+)

--- a/app/src/main/java/com/spark/android/data/remote/repository/AuthRepository.kt
+++ b/app/src/main/java/com/spark/android/data/remote/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.spark.android.data.remote.repository
 
 import com.spark.android.data.remote.entity.response.BaseResponse
+import com.spark.android.data.remote.entity.response.DoorbellResponse
 import com.spark.android.data.remote.entity.response.SignUpResponse
 import okhttp3.Callback
 import okhttp3.MultipartBody
@@ -11,6 +12,8 @@ interface AuthRepository {
 
     fun getFcmToken(getFcmToken: (String) -> Unit)
 
+    fun saveAccessToken(accessToken: String)
+
     suspend fun postSignUp(
         nickname: String,
         kakaoUserId: String,
@@ -18,5 +21,8 @@ interface AuthRepository {
         profileImg: MultipartBody.Part?
     ): Result<BaseResponse<SignUpResponse>>
 
-    fun saveAccessToken(accessToken: String)
+    suspend fun getAccessToken(
+        socialId: String,
+        fcmToken: String
+    ): Result<BaseResponse<DoorbellResponse>>
 }

--- a/app/src/main/java/com/spark/android/data/remote/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/spark/android/data/remote/repository/AuthRepositoryImpl.kt
@@ -6,6 +6,8 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.kakao.sdk.user.UserApiClient
 import com.spark.android.data.local.datasource.LocalPreferencesDataSource
 import com.spark.android.data.remote.datasource.AuthDataSource
+import com.spark.android.data.remote.entity.response.BaseResponse
+import com.spark.android.data.remote.entity.response.DoorbellResponse
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -37,6 +39,10 @@ class AuthRepositoryImpl @Inject constructor(
         })
     }
 
+    override fun saveAccessToken(accessToken: String) {
+        localPreferencesDataSource.saveAccessToken(accessToken)
+    }
+
     override suspend fun postSignUp(
         nickname: String,
         kakaoUserId: String,
@@ -50,7 +56,9 @@ class AuthRepositoryImpl @Inject constructor(
         authDataSource.postSignUp(map, profileImg)
     }
 
-    override fun saveAccessToken(accessToken: String) {
-        localPreferencesDataSource.saveAccessToken(accessToken)
-    }
+    override suspend fun getAccessToken(
+        socialId: String,
+        fcmToken: String
+    ): Result<BaseResponse<DoorbellResponse>> =
+        kotlin.runCatching { authDataSource.getAccessToken(socialId, fcmToken) }
 }

--- a/app/src/main/java/com/spark/android/data/remote/service/AuthService.kt
+++ b/app/src/main/java/com/spark/android/data/remote/service/AuthService.kt
@@ -1,15 +1,17 @@
 package com.spark.android.data.remote.service
 
-import com.spark.android.data.remote.entity.request.SignUpRequest
 import com.spark.android.data.remote.entity.response.BaseResponse
+import com.spark.android.data.remote.entity.response.DoorbellResponse
 import com.spark.android.data.remote.entity.response.SignUpResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.PartMap
+import retrofit2.http.Query
 
 interface AuthService {
     @Multipart
@@ -24,4 +26,10 @@ interface AuthService {
     suspend fun postSignUp(
         @PartMap map: Map<String, @JvmSuppressWildcards RequestBody>
     ): BaseResponse<SignUpResponse>
+
+    @GET("auth/doorbell")
+    suspend fun getAccessToken(
+        @Query("socialId") socialId: String,
+        @Query("fcmToken") fcmToken: String
+    ): BaseResponse<DoorbellResponse>
 }

--- a/app/src/main/java/com/spark/android/ui/auth/signin/SignInViewModel.kt
+++ b/app/src/main/java/com/spark/android/ui/auth/signin/SignInViewModel.kt
@@ -2,16 +2,48 @@ package com.spark.android.ui.auth.signin
 
 import android.util.Log
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.auth.model.OAuthToken
+import com.spark.android.data.remote.entity.response.DoorbellResponse
+import com.spark.android.data.remote.repository.AuthRepository
 import com.spark.android.util.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class SignInViewModel : ViewModel() {
+@HiltViewModel
+class SignInViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
     private val _isSuccessKakaoLogin = MutableLiveData<Event<Boolean>>()
     val isSuccessKakaoLogin: LiveData<Event<Boolean>> = _isSuccessKakaoLogin
+
+    private val _kakaoUserId = MutableLiveData<String>()
+    val kakaoUserId: LiveData<String> = _kakaoUserId
+
+    private val _fcmToken = MutableLiveData<String>()
+    val fcmToken: LiveData<String> = _fcmToken
+
+    private val _isInitUserInfo = MediatorLiveData<Boolean>()
+    val isInitUserInfo: LiveData<Boolean> = _isInitUserInfo
+
+    private val _doorbellResponse = MutableLiveData<DoorbellResponse>()
+    val doorbellResponse: LiveData<DoorbellResponse> = _doorbellResponse
+
+
+    fun addSourcesToIsInitUserInfo() {
+        with(_isInitUserInfo) {
+            this.addSource(_kakaoUserId) { id ->
+                this.value = id.isNotBlank() && fcmToken.value != null
+            }
+            this.addSource(_fcmToken) { token ->
+                this.value = token.isNotBlank() && kakaoUserId.value != null
+            }
+        }
+    }
 
     val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         if (error != null) {
@@ -23,7 +55,33 @@ class SignInViewModel : ViewModel() {
         }
     }
 
+    fun initKakaoUserId() {
+        authRepository.initKakaoUserId { id -> _kakaoUserId.value = id }
+    }
+
+    fun initFcmToken() {
+        authRepository.getFcmToken { token -> _fcmToken.value = token }
+    }
+
+    fun saveAccessToken() {
+        authRepository.saveAccessToken(requireNotNull(doorbellResponse.value).accesstoken)
+    }
+
     private fun initIsSuccessLogin(isSuccess: Boolean) {
         _isSuccessKakaoLogin.value = Event(isSuccess)
+    }
+
+    fun getAccessToken() {
+        viewModelScope.launch {
+            authRepository.getAccessToken(
+                requireNotNull(kakaoUserId.value),
+                requireNotNull(fcmToken.value)
+            ).onSuccess { response ->
+                _doorbellResponse.postValue(requireNotNull(response.data))
+            }.onFailure {
+                Log.d("SignIn_getAccessToken", it.message.toString())
+            }
+        }
+
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
     <!-- CertifyBottomSheet -->
     <string name="certify_camera">카메라 촬영</string>
     <string name="certify_album">앨범에서 선택</string>
+    <string name="sign_in_complete_login_msg">로그인되었습니다.</string>
 
 </resources>
 


### PR DESCRIPTION
## 관련 이슈번호
- #145
## 화면 이름
- 회원여부 판별 서버 연결
## 완료 태스크
- [x] 카카오 로그인 화면에서 카카오 로그인 후 회원여부 판별 서버 연결
- [x] 회원일 경우 메인화면으로 이동
- [x] 비회원일 경우 회원가입 화면으로 이동