### PR TITLE
#188 [fix] 사진 회전되어서 서버에 보내지는 문제 해결

### DIFF
--- a/app/src/main/java/com/spark/android/util/MultiPartResolver.kt
+++ b/app/src/main/java/com/spark/android/util/MultiPartResolver.kt
@@ -1,16 +1,23 @@
 package com.spark.android.util
 
 import android.content.Context
+import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
 import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
 import dagger.hilt.android.qualifiers.ActivityContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
+import java.lang.Exception
 import javax.inject.Inject
+import java.lang.NullPointerException
+
 
 class MultiPartResolver @Inject constructor(
     @ActivityContext private val context: Context
@@ -19,8 +26,10 @@ class MultiPartResolver @Inject constructor(
         val options = BitmapFactory.Options()
         val inputStream = context.contentResolver.openInputStream(uri)
         val byteArrayOutputStream = ByteArrayOutputStream()
-        BitmapFactory.decodeStream(inputStream, null, options)
-            ?.compress(Bitmap.CompressFormat.JPEG, 50, byteArrayOutputStream)
+        getRotatedBitmap(
+            BitmapFactory.decodeStream(inputStream, null, options),
+            getOrientationOfImage(uri)
+        )?.compress(Bitmap.CompressFormat.JPEG, 50, byteArrayOutputStream)
         val file = File(replaceFileName(uri.toString()))
         val surveyBody =
             byteArrayOutputStream.toByteArray().toRequestBody("image/jpeg".toMediaTypeOrNull())
@@ -34,6 +43,49 @@ class MultiPartResolver @Inject constructor(
         val surveyBody =
             byteArrayOutputStream.toByteArray().toRequestBody("image/jpeg".toMediaTypeOrNull())
         return MultipartBody.Part.createFormData("file", file.name, surveyBody)
+    }
+
+    private fun getOrientationOfImage(uri: Uri): Int {
+        var exif: ExifInterface? = null
+        try {
+            val filePath = getPathFromUri(uri)
+            exif = ExifInterface(filePath)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return -1
+        }
+        val orientation: Int = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, -1)
+        if (orientation != -1) {
+            when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> return 90
+                ExifInterface.ORIENTATION_ROTATE_180 -> return 180
+                ExifInterface.ORIENTATION_ROTATE_270 -> return 270
+            }
+        }
+        return 0
+    }
+
+    @Throws(Exception::class)
+    fun getRotatedBitmap(bitmap: Bitmap?, degrees: Int): Bitmap? {
+        if (bitmap == null) return null
+        if (degrees == 0) return bitmap
+        val matrix = Matrix()
+        matrix.postRotate(degrees.toFloat())
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+    }
+
+    private fun getPathFromUri(uri: Uri): String {
+        val cursor: Cursor = context.contentResolver.query(uri, null, null, null, null)
+            ?: throw NullPointerException()
+        cursor.moveToNext()
+        val columnIndex = cursor.getColumnIndex("_data")
+        val path = if (columnIndex >= 0) {
+            cursor.getString(columnIndex)
+        } else {
+            throw IllegalAccessException()
+        }
+        cursor.close()
+        return path
     }
 
     private fun replaceFileName(fileName: String): String = "${fileName.replace(".", "_")}.jpeg"


### PR DESCRIPTION
## 관련 이슈번호
- #188
## 화면 이름
- 사진 사용 화면
## 완료 태스크
- [x] 사진 회전되어서 서버에 보내지는 문제 해결
- [x] 사진찍어서 업로드할경우 사진 저장되는 문제도 해결
- [x] Image의 Orientation 얻어서 사진 각도 재설정하여 서버에 보내도록 구현