### PR TITLE
#257 [푸시알림] 알림 종류 별 푸시알림 레이아웃 설정

### DIFF
--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
@@ -16,8 +17,14 @@ import com.google.firebase.messaging.RemoteMessage
 import com.spark.android.ui.intro.IntroActivity
 import com.spark.android.util.ImageUrlTransformer
 import java.lang.IllegalArgumentException
+import java.lang.IllegalStateException
 
 class SparkMessagingService : FirebaseMessagingService() {
+    data class NotificationCategory(
+        val summaryId: Int,
+        val groupName: String
+    )
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
     }
@@ -35,6 +42,7 @@ class SparkMessagingService : FirebaseMessagingService() {
 
     private fun showNotificationWithoutImage(remoteMessage: RemoteMessage) {
         val alarmId = remoteMessage.sentTime.toInt()
+        val category = remoteMessage.data["category"].toString()
         val intent = Intent(this, IntroActivity::class.java)
         val pendingIntent =
             PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
@@ -46,6 +54,8 @@ class SparkMessagingService : FirebaseMessagingService() {
                 .setContentIntent(pendingIntent)
                 .setPriority(NotificationCompat.PRIORITY_MAX)
                 .setAutoCancel(true)
+                .setGroup(category)
+
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         val channelId = getString(R.string.app_name)
@@ -54,10 +64,12 @@ class SparkMessagingService : FirebaseMessagingService() {
         val channel = NotificationChannel(channelId, channelName, channelImportance)
         notificationManager.createNotificationChannel(channel)
         notificationManager.notify(alarmId, builder.build())
+        notificationManager.notify(getSummaryId(category), getSummary(category).build())
     }
 
     private fun showNotificationWithImage(remoteMessage: RemoteMessage, bitmap: Bitmap) {
         val alarmId = remoteMessage.sentTime.toInt()
+        val category = remoteMessage.data["category"].toString()
         val intent = Intent(this, IntroActivity::class.java)
         val pendingIntent =
             PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
@@ -69,6 +81,7 @@ class SparkMessagingService : FirebaseMessagingService() {
             .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setAutoCancel(true)
+            .setGroup(category)
 
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -78,6 +91,7 @@ class SparkMessagingService : FirebaseMessagingService() {
         val channel = NotificationChannel(channelId, channelName, channelImportance)
         notificationManager.createNotificationChannel(channel)
         notificationManager.notify(alarmId, builder.build())
+        notificationManager.notify(getSummaryId(category), getSummary(category).build())
     }
 
     private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
@@ -95,5 +109,29 @@ class SparkMessagingService : FirebaseMessagingService() {
 
                 override fun onLoadCleared(placeholder: Drawable?) {}
             })
+    }
+
+    private fun getSummary(category: String) =
+        NotificationCompat.Builder(this, getString(R.string.app_name))
+            .setSmallIcon(R.mipmap.ic_app_logo)
+            .setContentTitle(getString(R.string.app_name))
+            .setGroup(category)
+            .setGroupSummary(true)
+
+    private fun getSummaryId(category: String) = when (category) {
+        CATEGORY_CERTIFICATION.groupName -> CATEGORY_CERTIFICATION.summaryId
+        CATEGORY_SPARK.groupName -> CATEGORY_SPARK.summaryId
+        CATEGORY_REMIND.groupName -> CATEGORY_REMIND.summaryId
+        CATEGORY_ROOM_START.groupName -> CATEGORY_ROOM_START.summaryId
+        CATEGORY_CONSIDER.groupName -> CATEGORY_CONSIDER.summaryId
+        else -> throw IllegalArgumentException("FCM category 필드 오류")
+    }
+
+    companion object {
+        private val CATEGORY_CERTIFICATION = NotificationCategory(0, "certification")
+        private val CATEGORY_SPARK = NotificationCategory(1, "spark")
+        private val CATEGORY_REMIND = NotificationCategory(2, "remind")
+        private val CATEGORY_ROOM_START = NotificationCategory(3, "roomStart")
+        private val CATEGORY_CONSIDER = NotificationCategory(4, "consider")
     }
 }

--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -14,6 +14,7 @@ import com.bumptech.glide.request.transition.Transition
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.spark.android.ui.intro.IntroActivity
+import com.spark.android.util.ImageUrlTransformer
 import java.lang.IllegalArgumentException
 
 class SparkMessagingService : FirebaseMessagingService() {
@@ -97,16 +98,10 @@ class SparkMessagingService : FirebaseMessagingService() {
 
     private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
         val imageUrl = remoteMessage.data["imageUrl"].toString()
-        val imageType = when {
-            imageUrl.contains(JPEG) -> JPEG
-            imageUrl.contains(PNG) -> PNG
-            else -> throw IllegalArgumentException("FCM imageUrl 이미지 확장자 에러")
-        }
-        val resizeImagedUrl = imageUrl.replace(imageType, SMALL_IMG_SIZE + imageType)
         when (remoteMessage.data["expand"].toString()) {
             EXPAND -> Glide.with(this)
                 .asBitmap()
-                .load(resizeImagedUrl)
+                .load(ImageUrlTransformer.getSmallSizeImageUrl(imageUrl))
                 .into(object : CustomTarget<Bitmap>() {
                     override fun onResourceReady(
                         resource: Bitmap,
@@ -120,7 +115,7 @@ class SparkMessagingService : FirebaseMessagingService() {
                 })
             NOT_EXPAND -> Glide.with(this)
                 .asBitmap()
-                .load(resizeImagedUrl)
+                .load(ImageUrlTransformer.getSmallSizeImageUrl(imageUrl))
                 .circleCrop()
                 .into(object : CustomTarget<Bitmap>() {
                     override fun onResourceReady(
@@ -138,8 +133,5 @@ class SparkMessagingService : FirebaseMessagingService() {
     companion object {
         private const val EXPAND = "enable"
         private const val NOT_EXPAND = "disable"
-        private const val SMALL_IMG_SIZE = "_270x270"
-        private const val JPEG = ".jpeg"
-        private const val PNG = ".png"
     }
 }

--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -61,30 +61,14 @@ class SparkMessagingService : FirebaseMessagingService() {
         val intent = Intent(this, IntroActivity::class.java)
         val pendingIntent =
             PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
-        val builder = when (remoteMessage.data["expand"].toString()) {
-            EXPAND -> NotificationCompat.Builder(this, getString(R.string.app_name))
-                .setContentTitle(remoteMessage.data["title"].toString())
-                .setContentText(remoteMessage.data["body"].toString())
-                .setSmallIcon(R.mipmap.ic_app_logo)
-                .setLargeIcon(bitmap)
-                .setStyle(
-                    NotificationCompat.BigPictureStyle()
-                        .bigPicture(bitmap)
-                        .bigLargeIcon(null)
-                )
-                .setContentIntent(pendingIntent)
-                .setPriority(NotificationCompat.PRIORITY_MAX)
-                .setAutoCancel(true)
-            NOT_EXPAND -> NotificationCompat.Builder(this, getString(R.string.app_name))
-                .setContentTitle(remoteMessage.data["title"].toString())
-                .setContentText(remoteMessage.data["body"].toString())
-                .setSmallIcon(R.mipmap.ic_app_logo)
-                .setLargeIcon(bitmap)
-                .setContentIntent(pendingIntent)
-                .setPriority(NotificationCompat.PRIORITY_MAX)
-                .setAutoCancel(true)
-            else -> throw IllegalArgumentException("FCM expand 필드값 에러")
-        }
+        val builder = NotificationCompat.Builder(this, getString(R.string.app_name))
+            .setContentTitle(remoteMessage.data["title"].toString())
+            .setContentText(remoteMessage.data["body"].toString())
+            .setSmallIcon(R.mipmap.ic_app_logo)
+            .setLargeIcon(bitmap)
+            .setContentIntent(pendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_MAX)
+            .setAutoCancel(true)
 
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -98,40 +82,18 @@ class SparkMessagingService : FirebaseMessagingService() {
 
     private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
         val imageUrl = remoteMessage.data["imageUrl"].toString()
-        when (remoteMessage.data["expand"].toString()) {
-            EXPAND -> Glide.with(this)
-                .asBitmap()
-                .load(ImageUrlTransformer.getSmallSizeImageUrl(imageUrl))
-                .into(object : CustomTarget<Bitmap>() {
-                    override fun onResourceReady(
-                        resource: Bitmap,
-                        transition: Transition<in Bitmap>?
-                    ) {
-                        showNotificationWithImage(remoteMessage, resource)
-                    }
+        Glide.with(this)
+            .asBitmap()
+            .load(ImageUrlTransformer.getSmallSizeImageUrl(imageUrl))
+            .into(object : CustomTarget<Bitmap>() {
+                override fun onResourceReady(
+                    resource: Bitmap,
+                    transition: Transition<in Bitmap>?
+                ) {
+                    showNotificationWithImage(remoteMessage, resource)
+                }
 
-                    override fun onLoadCleared(placeholder: Drawable?) {}
-
-                })
-            NOT_EXPAND -> Glide.with(this)
-                .asBitmap()
-                .load(ImageUrlTransformer.getSmallSizeImageUrl(imageUrl))
-                .circleCrop()
-                .into(object : CustomTarget<Bitmap>() {
-                    override fun onResourceReady(
-                        resource: Bitmap,
-                        transition: Transition<in Bitmap>?
-                    ) {
-                        showNotificationWithImage(remoteMessage, resource)
-                    }
-
-                    override fun onLoadCleared(placeholder: Drawable?) {}
-                })
-        }
-    }
-
-    companion object {
-        private const val EXPAND = "enable"
-        private const val NOT_EXPAND = "disable"
+                override fun onLoadCleared(placeholder: Drawable?) {}
+            })
     }
 }

--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -96,10 +96,17 @@ class SparkMessagingService : FirebaseMessagingService() {
     }
 
     private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
+        val imageUrl = remoteMessage.data["imageUrl"].toString()
+        val imageType = when {
+            imageUrl.contains(JPEG) -> JPEG
+            imageUrl.contains(PNG) -> PNG
+            else -> throw IllegalArgumentException("FCM imageUrl 이미지 확장자 에러")
+        }
+        val resizeImagedUrl = imageUrl.replace(imageType, SMALL_IMG_SIZE + imageType)
         when (remoteMessage.data["expand"].toString()) {
             EXPAND -> Glide.with(this)
                 .asBitmap()
-                .load(remoteMessage.data["imageUrl"].toString())
+                .load(resizeImagedUrl)
                 .into(object : CustomTarget<Bitmap>() {
                     override fun onResourceReady(
                         resource: Bitmap,
@@ -113,7 +120,7 @@ class SparkMessagingService : FirebaseMessagingService() {
                 })
             NOT_EXPAND -> Glide.with(this)
                 .asBitmap()
-                .load(remoteMessage.data["imageUrl"].toString())
+                .load(resizeImagedUrl)
                 .circleCrop()
                 .into(object : CustomTarget<Bitmap>() {
                     override fun onResourceReady(
@@ -131,5 +138,8 @@ class SparkMessagingService : FirebaseMessagingService() {
     companion object {
         private const val EXPAND = "enable"
         private const val NOT_EXPAND = "disable"
+        private const val SMALL_IMG_SIZE = "_270x270"
+        private const val JPEG = ".jpeg"
+        private const val PNG = ".png"
     }
 }

--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -5,10 +5,16 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import androidx.core.app.NotificationCompat
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.spark.android.ui.intro.IntroActivity
+import java.lang.IllegalArgumentException
 
 class SparkMessagingService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
@@ -18,11 +24,15 @@ class SparkMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         super.onMessageReceived(remoteMessage)
         if (remoteMessage.data.isNotEmpty()) {
-            showNotification(remoteMessage)
+            if (remoteMessage.data["imageUrl"].toString().isNotBlank()) {
+                transformImageUrlToBitmap(remoteMessage)
+            } else {
+                showNotificationWithoutImage(remoteMessage)
+            }
         }
     }
 
-    private fun showNotification(remoteMessage: RemoteMessage) {
+    private fun showNotificationWithoutImage(remoteMessage: RemoteMessage) {
         val alarmId = remoteMessage.sentTime.toInt()
         val intent = Intent(this, IntroActivity::class.java)
         val pendingIntent =
@@ -43,5 +53,83 @@ class SparkMessagingService : FirebaseMessagingService() {
         val channel = NotificationChannel(channelId, channelName, channelImportance)
         notificationManager.createNotificationChannel(channel)
         notificationManager.notify(alarmId, builder.build())
+    }
+
+    private fun showNotificationWithImage(remoteMessage: RemoteMessage, bitmap: Bitmap) {
+        val alarmId = remoteMessage.sentTime.toInt()
+        val intent = Intent(this, IntroActivity::class.java)
+        val pendingIntent =
+            PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        val builder = when (remoteMessage.data["expand"].toString()) {
+            EXPAND -> NotificationCompat.Builder(this, getString(R.string.app_name))
+                .setContentTitle(remoteMessage.data["title"].toString())
+                .setContentText(remoteMessage.data["body"].toString())
+                .setSmallIcon(R.mipmap.ic_app_logo)
+                .setLargeIcon(bitmap)
+                .setStyle(
+                    NotificationCompat.BigPictureStyle()
+                        .bigPicture(bitmap)
+                        .bigLargeIcon(null)
+                )
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setAutoCancel(true)
+            NOT_EXPAND -> NotificationCompat.Builder(this, getString(R.string.app_name))
+                .setContentTitle(remoteMessage.data["title"].toString())
+                .setContentText(remoteMessage.data["body"].toString())
+                .setSmallIcon(R.mipmap.ic_app_logo)
+                .setLargeIcon(bitmap)
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setAutoCancel(true)
+            else -> throw IllegalArgumentException("FCM expand 필드값 에러")
+        }
+
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channelId = getString(R.string.app_name)
+        val channelName = getString(R.string.app_name)
+        val channelImportance = NotificationManager.IMPORTANCE_HIGH
+        val channel = NotificationChannel(channelId, channelName, channelImportance)
+        notificationManager.createNotificationChannel(channel)
+        notificationManager.notify(alarmId, builder.build())
+    }
+
+    private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
+        when (remoteMessage.data["expand"].toString()) {
+            EXPAND -> Glide.with(this)
+                .asBitmap()
+                .load(remoteMessage.data["imageUrl"].toString())
+                .into(object : CustomTarget<Bitmap>() {
+                    override fun onResourceReady(
+                        resource: Bitmap,
+                        transition: Transition<in Bitmap>?
+                    ) {
+                        showNotificationWithImage(remoteMessage, resource)
+                    }
+
+                    override fun onLoadCleared(placeholder: Drawable?) {}
+
+                })
+            NOT_EXPAND -> Glide.with(this)
+                .asBitmap()
+                .load(remoteMessage.data["imageUrl"].toString())
+                .circleCrop()
+                .into(object : CustomTarget<Bitmap>() {
+                    override fun onResourceReady(
+                        resource: Bitmap,
+                        transition: Transition<in Bitmap>?
+                    ) {
+                        showNotificationWithImage(remoteMessage, resource)
+                    }
+
+                    override fun onLoadCleared(placeholder: Drawable?) {}
+                })
+        }
+    }
+
+    companion object {
+        private const val EXPAND = "enable"
+        private const val NOT_EXPAND = "disable"
     }
 }

--- a/app/src/main/java/com/spark/android/util/ImageUrlTransformer.kt
+++ b/app/src/main/java/com/spark/android/util/ImageUrlTransformer.kt
@@ -1,0 +1,32 @@
+package com.spark.android.util
+
+import java.lang.IllegalArgumentException
+
+object ImageUrlTransformer {
+    private const val SMALL_IMG_SIZE = "_270x270"
+    private const val MEDIUM_IMG_SIZE = "_360x360"
+    private const val BIG_IMG_SIZE = "_720x720"
+    private const val JPEG = ".jpeg"
+    private const val PNG = ".png"
+
+    private fun getImageType(imageUrl: String): String = when {
+        imageUrl.contains(JPEG) -> JPEG
+        imageUrl.contains(PNG) -> PNG
+        else -> throw IllegalArgumentException("imageUrl 이미지 확장자 에러")
+    }
+
+    fun getSmallSizeImageUrl(
+        imageUrl: String,
+        imageType: String = getImageType(imageUrl)
+    ): String = imageUrl.replace(imageType, SMALL_IMG_SIZE + imageType)
+
+    fun getMediumSizeImageUrl(
+        imageUrl: String,
+        imageType: String = getImageType(imageUrl)
+    ): String = imageUrl.replace(imageType, MEDIUM_IMG_SIZE + imageType)
+
+    fun getBigSizeImageUrl(
+        imageUrl: String,
+        imageType: String = getImageType(imageUrl)
+    ): String = imageUrl.replace(imageType, BIG_IMG_SIZE + imageType)
+}


### PR DESCRIPTION
## ✒️관련 이슈번호
- #257 
## 💻화면 이름
    #257 푸쉬알림
## 완료 태스크
    #257
    - 사진 유무에 따른 푸시알림 레이아웃 설정
    - 사진 리사이징해서 가져오도록 구현 (인증사진은 확장되므로 270270, 720720 둘다 필요, 프로필은 270*270만 필요)
    - 이미지 URL -> 리사이징 URL로 변환하는 파일 추가 (Util/ImageUrlTransformer 추가)
    - 서버 필드명 상수로 빼기
    - 카테고리별 그룹핑


