### PR TITLE
#270 [이미지] 이미지 1:1 크롭 기능 추가

### DIFF
--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -14,6 +14,7 @@ import com.bumptech.glide.request.transition.Transition
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.spark.android.ui.intro.IntroActivity
+import com.spark.android.util.ImageCropUtil
 import com.spark.android.util.ImageUrlTransformer
 import java.lang.IllegalArgumentException
 
@@ -93,7 +94,12 @@ class SparkMessagingService : FirebaseMessagingService() {
             .load(ImageUrlTransformer.getSmallSizeImageUrl(imageUrl))
             .into(object : CustomTarget<Bitmap>() {
                 override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-                    createNotificationWithImage(remoteMessage, resource)
+                    val bitmap = if (resource.width != resource.height) {
+                        ImageCropUtil.squareCropBitmap(resource)
+                    } else {
+                        resource
+                    }
+                    createNotificationWithImage(remoteMessage, bitmap)
                 }
 
                 override fun onLoadCleared(placeholder: Drawable?) {}

--- a/app/src/main/java/com/spark/android/util/ImageCropUtil.kt
+++ b/app/src/main/java/com/spark/android/util/ImageCropUtil.kt
@@ -1,0 +1,21 @@
+package com.spark.android.util
+
+import android.graphics.Bitmap
+
+object ImageCropUtil {
+    fun squareCropBitmap(bitmap: Bitmap): Bitmap {
+        val originWidth = bitmap.width
+        val originHeight = bitmap.height
+        var x = 0
+        var y = 0
+        var resizedLength = 0
+        if (originWidth > originHeight) {
+            resizedLength = originHeight
+            x = (originWidth - resizedLength) / 2
+        } else {
+            resizedLength = originWidth
+            y = (originHeight - resizedLength) / 2
+        }
+        return Bitmap.createBitmap(bitmap, x, y, resizedLength, resizedLength)
+    }
+}


### PR DESCRIPTION
## ✒️관련 이슈번호
- #270
## 💻화면 이름
    #270 이미지 관련 작업
## 완료 태스크
    -  ImageCropUtil 생성 후 정방형 크롭 기능 메소드 추가 (가로, 세로 중 짧은 쪽 길이를 기준으로 크롭)

