### PR TITLE
[푸쉬알람] 카테고리 나눈 알람들 ChannelId 다르게 설정하기

### DIFF
--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -90,31 +90,22 @@ class SparkMessagingService : FirebaseMessagingService() {
     }
 
     private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
-        var isImgUploaded = false
-        var bitmap = requireNotNull(
-            ContextCompat.getDrawable(this, R.drawable.ic_habit_sticker_complete)
-        ).toBitmap(270, 270)
         val imageUrl = remoteMessage.data["imageUrl"].toString()
         Glide.with(this)
             .asBitmap()
             .load(ImageUrlTransformer.getSmallSizeImageUrl(imageUrl))
-            .error(R.mipmap.ic_app_logo)
             .into(object : CustomTarget<Bitmap>() {
                 override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-                    bitmap = if (resource.width != resource.height) {
+                    val bitmap = if (resource.width != resource.height) {
                         ImageCropUtil.squareCropBitmap(resource)
                     } else {
                         resource
                     }
-                    isImgUploaded = true
                     createNotificationWithImage(remoteMessage, bitmap)
                 }
 
                 override fun onLoadCleared(placeholder: Drawable?) {}
             })
-        if (!isImgUploaded) {
-            createNotificationWithImage(remoteMessage, bitmap)
-        }
     }
 
     private fun getSummary(category: String) =

--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -44,7 +44,7 @@ class SparkMessagingService : FirebaseMessagingService() {
     private fun showAlarm(alarmId: Int, category: String, builder: NotificationCompat.Builder) {
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channelId = getString(R.string.app_name)
+        val channelId = getString(R.string.app_name) + category
         val channelName = getString(R.string.app_name)
         val channelImportance = NotificationManager.IMPORTANCE_HIGH
         val channel = NotificationChannel(channelId, channelName, channelImportance)
@@ -91,8 +91,9 @@ class SparkMessagingService : FirebaseMessagingService() {
 
     private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
         var isImgUploaded = false
-        var bitmap =
-            requireNotNull(ContextCompat.getDrawable(this, R.drawable.ic_habit_sticker_complete)).toBitmap(240, 240)
+        var bitmap = requireNotNull(
+            ContextCompat.getDrawable(this, R.drawable.ic_habit_sticker_complete)
+        ).toBitmap(270, 270)
         val imageUrl = remoteMessage.data["imageUrl"].toString()
         Glide.with(this)
             .asBitmap()
@@ -111,7 +112,7 @@ class SparkMessagingService : FirebaseMessagingService() {
 
                 override fun onLoadCleared(placeholder: Drawable?) {}
             })
-        if(!isImgUploaded){
+        if (!isImgUploaded) {
             createNotificationWithImage(remoteMessage, bitmap)
         }
     }


### PR DESCRIPTION
## ✒️관련 이슈번호
- #280
## 💻화면 이름
    #280 푸쉬알람
## 완료 태스크
	- 푸쉬알림 카테고리마다 채널 아이디값 다르게 하기
같게 하니까 하나의 카테고리알림 없앨때 다같이 사라짐
채널 명도 다르게 할지 기획한테 물어보기
