### PR TITLE
#350 [인증 완료 다이얼로그] 날짜별 분기처리 및 레이아웃 수정

### DIFF
--- a/app/src/main/java/com/spark/android/ui/certify/CertifyActivity.kt
+++ b/app/src/main/java/com/spark/android/ui/certify/CertifyActivity.kt
@@ -128,7 +128,9 @@ class CertifyActivity : BaseActivity<ActivityCertifyBinding>(R.layout.activity_c
     private fun initIsSuccessCertifyObserver() {
         certifyViewModel.isSuccessCertify.observe(this) { isSuccess ->
             if (isSuccess) {
-                InstaShareDialogFragment().show(supportFragmentManager, this.javaClass.name)
+                InstaShareDialogFragment().apply {
+                    Bundle().putInt("leftDay", intent.getIntExtra("leftDay", -1))
+                }.show(supportFragmentManager, this.javaClass.name)
             }
         }
     }

--- a/app/src/main/java/com/spark/android/ui/certify/CertifyActivity.kt
+++ b/app/src/main/java/com/spark/android/ui/certify/CertifyActivity.kt
@@ -129,7 +129,9 @@ class CertifyActivity : BaseActivity<ActivityCertifyBinding>(R.layout.activity_c
         certifyViewModel.isSuccessCertify.observe(this) { isSuccess ->
             if (isSuccess) {
                 InstaShareDialogFragment().apply {
-                    Bundle().putInt("leftDay", intent.getIntExtra("leftDay", -1))
+                    arguments = Bundle().apply {
+                        putInt("leftDay", intent.getIntExtra("leftDay", -1))
+                    }
                 }.show(supportFragmentManager, this.javaClass.name)
             }
         }

--- a/app/src/main/java/com/spark/android/ui/certify/CertifyBottomSheet.kt
+++ b/app/src/main/java/com/spark/android/ui/certify/CertifyBottomSheet.kt
@@ -78,8 +78,9 @@ class CertifyBottomSheet : BottomSheetDialogFragment() {
         arguments?.getString("profileImgUrl")?.let { certifyViewModel.initProfileImg(it) }
         arguments?.getString("nickname")?.let { certifyViewModel.initNickName(it) }
         arguments?.getInt("certifyMode")?.let { certifyViewModel.initCertifyMode(it) }
-        arguments?.getBoolean("onlyCameraInitial")
-            ?.let { certifyViewModel.initOnlyCameraInitial(it) }
+        arguments?.getBoolean("onlyCameraInitial")?.let {
+            certifyViewModel.initOnlyCameraInitial(it)
+        }
     }
 
     private fun initFromAlbumBtnClickListener() {
@@ -151,6 +152,7 @@ class CertifyBottomSheet : BottomSheetDialogFragment() {
                     putExtra("onlyCameraInitial", false)
                     putExtra("profileImgUrl", certifyViewModel.profileImg.value)
                     putExtra("imgUri", certifyViewModel.imgUri.value)
+                    arguments?.getInt("leftDay")?.let { putExtra("leftDay", it) }
                 }
                 startActivity(intent)
             }

--- a/app/src/main/java/com/spark/android/ui/habit/HabitTodayBottomSheet.kt
+++ b/app/src/main/java/com/spark/android/ui/habit/HabitTodayBottomSheet.kt
@@ -51,11 +51,14 @@ class HabitTodayBottomSheet : BottomSheetDialogFragment() {
         val bundle = Bundle()
         habitViewModel.habitInfo.value?.roomId?.let { it1 -> bundle.putInt("roomId", it1) }
         bundle.putString("roomName", habitViewModel.habitInfo.value?.roomName.toString())
-        bundle.putString("profileImgUrl",
-            habitViewModel.habitInfo.value?.myRecord?.profileImg.toString())
+        bundle.putString(
+            "profileImgUrl",
+            habitViewModel.habitInfo.value?.myRecord?.profileImg.toString()
+        )
         bundle.putString("nickname", habitViewModel.habitInfo.value?.myRecord?.nickname.toString())
         bundle.putInt("certifyMode", CertifyMode.ONLY_CAMERA_MODE)
         bundle.putBoolean("onlyCameraInitial", true)
+        bundle.putInt("leftDay", requireNotNull(habitViewModel.habitInfo.value).leftDay)
         certifyBottomSheet.arguments = bundle
         certifyBottomSheet.show(
             requireActivity().supportFragmentManager,
@@ -76,6 +79,7 @@ class HabitTodayBottomSheet : BottomSheetDialogFragment() {
                         "profileImgUrl",
                         habitViewModel.habitInfo.value?.myRecord?.profileImg.toString()
                     )
+                    putExtra("leftDay", habitViewModel.habitInfo.value?.leftDay)
                 }
                 startActivity(intent)
                 dismiss()

--- a/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
+++ b/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
@@ -40,7 +40,7 @@ class InstaShareDialogFragment : DialogFragment() {
             requireNotNull(window).apply {
                 setCancelable(false)
                 setLayout(
-                    (resources.displayMetrics.widthPixels * 0.99).toInt(),
+                    (resources.displayMetrics.widthPixels * 0.88).toInt(),
                     ViewGroup.LayoutParams.WRAP_CONTENT
                 )
                 setBackgroundDrawableResource(R.drawable.shape_spark_white_fill_2_rect)

--- a/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
+++ b/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
@@ -39,7 +39,7 @@ class InstaShareDialogFragment : DialogFragment() {
             requireNotNull(window).apply {
                 setCancelable(false)
                 setLayout(
-                    (resources.displayMetrics.widthPixels * 0.85).toInt(),
+                    (resources.displayMetrics.widthPixels * 0.99).toInt(),
                     ViewGroup.LayoutParams.WRAP_CONTENT
                 )
                 setBackgroundDrawableResource(R.drawable.shape_spark_white_fill_2_rect)

--- a/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
+++ b/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
@@ -25,6 +25,7 @@ class InstaShareDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.leftDay = arguments?.getInt("leftDay") ?: -1
         setConfirmTextClickListener()
         setCancelTextClickListener()
     }

--- a/app/src/main/java/com/spark/android/ui/timer/TimerStartActivity.kt
+++ b/app/src/main/java/com/spark/android/ui/timer/TimerStartActivity.kt
@@ -106,6 +106,7 @@ class TimerStartActivity : BaseActivity<ActivityTimerStartBinding>(R.layout.acti
                 putExtra("certifyMode", CertifyMode.NORMAL_READY_MODE)
                 putExtra("profileImgUrl", profileImgUrl)
                 putExtra("nickname", nickname)
+                putExtra("leftDay", intent.getIntExtra("leftDay", -1))
             }
             startActivity(intent)
             finish()

--- a/app/src/main/java/com/spark/android/util/BindingAdapters.kt
+++ b/app/src/main/java/com/spark/android/util/BindingAdapters.kt
@@ -10,6 +10,7 @@ import com.airbnb.lottie.LottieAnimationView
 import com.bumptech.glide.Glide
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.spark.android.R
+import java.lang.IllegalArgumentException
 
 object BindingAdapters {
     @JvmStatic
@@ -520,9 +521,9 @@ object BindingAdapters {
     @JvmStatic
     @BindingAdapter("setFinishRoomDialogTitle")
     fun setFinishRoomDialogTitle(textview: TextView, myStatus: String?) {
-        if(myStatus == "COMPLETE"){
+        if (myStatus == "COMPLETE") {
             textview.setText(R.string.finish_room_dialog_success_title)
-        }else if (myStatus == "FAIL"){
+        } else if (myStatus == "FAIL") {
             textview.setText(R.string.finish_room_dialog_fail_title)
         }
     }
@@ -530,11 +531,27 @@ object BindingAdapters {
     @JvmStatic
     @BindingAdapter("setFinishRoomDialogContent")
     fun setFinishRoomDialogContent(textview: TextView, myStatus: String?) {
-        if(myStatus == "COMPLETE"){
+        if (myStatus == "COMPLETE") {
             textview.setText(R.string.finish_room_dialog_success_content)
-        }else if (myStatus == "FAIL"){
+        } else if (myStatus == "FAIL") {
             textview.setText(R.string.finish_room_dialog_fail_content)
         }
+    }
+
+    @JvmStatic
+    @BindingAdapter("setShareDialogContent")
+    fun TextView.setShareDialogContent(leftDay: Int) {
+        this.setText(
+            when (leftDay) {
+                in 1..2 -> R.string.insta_left_day_1_content
+                in 3..6 -> R.string.insta_left_day_3_content
+                in 7..32 -> R.string.insta_left_day_7_content
+                in 33..58 -> R.string.insta_left_day_33_content
+                in 59..65 -> R.string.insta_left_day_59_content
+                66 -> R.string.insta_left_day_66_content
+                else -> throw IllegalArgumentException("leftDay 범위 에러")
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/spark/android/util/DialogUtil.kt
+++ b/app/src/main/java/com/spark/android/util/DialogUtil.kt
@@ -42,9 +42,10 @@ class DialogUtil(private val dialogMode: Int, private val doAfterConfirm: () -> 
         requireNotNull(dialog).apply {
             requireNotNull(window).apply {
                 setLayout(
-                    (resources.displayMetrics.widthPixels * 0.99).toInt(),
+                    (resources.displayMetrics.widthPixels * 0.91).toInt(),
                     ViewGroup.LayoutParams.WRAP_CONTENT
                 )
+                setBackgroundDrawableResource(R.drawable.shape_spark_white_fill_2_rect)
             }
         }
     }

--- a/app/src/main/res/layout/dialog_insta_share.xml
+++ b/app/src/main/res/layout/dialog_insta_share.xml
@@ -1,108 +1,118 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ImageView
-        android:id="@+id/iv_insta_pattern"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="21dp"
-        android:layout_marginTop="16dp"
-        android:contentDescription="@string/insta_desc_pattern_img"
-        android:src="@drawable/bg_insta_dialog"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-    <ImageView
-        android:id="@+id/iv_insta_clap"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:contentDescription="@string/insta_desc_clap_img"
-        android:src="@drawable/ic_insta_clap"
-        app:layout_constraintEnd_toEndOf="@id/iv_insta_pattern"
-        app:layout_constraintStart_toStartOf="@id/iv_insta_pattern"
-        app:layout_constraintTop_toTopOf="parent" />
+        <variable
+            name="leftDay"
+            type="Integer" />
+    </data>
 
-    <TextView
-        android:id="@+id/tv_insta_wow"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:fontFamily="@font/futura_medium_italic"
-        android:text="WOW!"
-        android:textColor="@color/spark_dark_pinkred"
-        android:textSize="24dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/iv_insta_clap" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/tv_insta_content"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:fontFamily="@font/noto_sans_kr_regular"
-        android:gravity="center"
-        android:includeFontPadding="false"
-        android:text="@string/insta_content_msg"
-        android:textColor="@color/spark_deep_gray"
-        android:textSize="16dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_insta_wow" />
+        <ImageView
+            android:id="@+id/iv_insta_pattern"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="21dp"
+            android:layout_marginTop="16dp"
+            android:contentDescription="@string/insta_desc_pattern_img"
+            android:src="@drawable/bg_insta_dialog"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btn_insta_share"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="28dp"
-        android:background="@drawable/shape_insta_black_fiil_2"
-        android:drawableStart="@drawable/ic_instagram"
-        android:drawablePadding="7dp"
-        android:fontFamily="@font/noto_sans_kr_bold"
-        android:includeFontPadding="false"
-        android:paddingHorizontal="20dp"
-        android:paddingTop="13dp"
-        android:paddingBottom="14dp"
-        android:stateListAnimator="@null"
-        android:text="@string/insta_btn_msg"
-        android:textColor="@color/spark_white"
-        android:textSize="18dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_insta_content" />
+        <ImageView
+            android:id="@+id/iv_insta_clap"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:contentDescription="@string/insta_desc_clap_img"
+            android:src="@drawable/ic_insta_clap"
+            app:layout_constraintEnd_toEndOf="@id/iv_insta_pattern"
+            app:layout_constraintStart_toStartOf="@id/iv_insta_pattern"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/tv_insta_cancel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:layout_marginBottom="28dp"
-        android:fontFamily="@font/noto_sans_kr_regular"
-        android:includeFontPadding="false"
-        android:text="@string/insta_cancel_msg"
-        android:textColor="@color/spark_dark_gray"
-        android:textSize="14dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/btn_insta_share"
-        app:layout_constraintStart_toStartOf="@id/btn_insta_share"
-        app:layout_constraintTop_toBottomOf="@id/btn_insta_share" />
+        <TextView
+            android:id="@+id/tv_insta_wow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/futura_medium_italic"
+            android:text="@{@string/insta_left_day_title(leftDay)}"
+            android:textColor="@color/spark_dark_pinkred"
+            android:textSize="24dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_insta_clap" />
+
+        <TextView
+            android:id="@+id/tv_insta_content"
+            setShareDialogContent="@{leftDay}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:textColor="@color/spark_deep_gray"
+            android:textSize="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_insta_wow" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_insta_share"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:background="@drawable/shape_insta_black_fiil_2"
+            android:drawableStart="@drawable/ic_instagram"
+            android:drawablePadding="7dp"
+            android:fontFamily="@font/noto_sans_kr_bold"
+            android:includeFontPadding="false"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="13dp"
+            android:paddingBottom="14dp"
+            android:stateListAnimator="@null"
+            android:text="@string/insta_btn_msg"
+            android:textColor="@color/spark_white"
+            android:textSize="18dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_insta_content" />
+
+        <TextView
+            android:id="@+id/tv_insta_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="28dp"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            android:includeFontPadding="false"
+            android:text="@string/insta_cancel_msg"
+            android:textColor="@color/spark_dark_gray"
+            android:textSize="14dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/btn_insta_share"
+            app:layout_constraintStart_toStartOf="@id/btn_insta_share"
+            app:layout_constraintTop_toBottomOf="@id/btn_insta_share" />
 
 
-    <com.airbnb.lottie.LottieAnimationView
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginHorizontal="32dp"
-        app:layout_constraintDimensionRatio="1:1"
-        app:layout_constraintEnd_toEndOf="@id/iv_insta_pattern"
-        app:layout_constraintStart_toStartOf="@id/iv_insta_pattern"
-        app:layout_constraintTop_toTopOf="parent"
-        app:lottie_autoPlay="true"
-        app:lottie_fileName="insta.json"
-        app:lottie_loop="true" />
+        <com.airbnb.lottie.LottieAnimationView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="32dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="@id/iv_insta_pattern"
+            app:layout_constraintStart_toStartOf="@id/iv_insta_pattern"
+            app:layout_constraintTop_toTopOf="parent"
+            app:lottie_autoPlay="true"
+            app:lottie_fileName="insta.json"
+            app:lottie_loop="true" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,8 +214,15 @@
     <string name="insta_desc_pattern_img">인스타 다이얼로그 패턴</string>
     <string name="insta_desc_clap_img">인스타 다이얼로그 박수 이미지</string>
     <string name="insta_btn_msg">인스타에 자랑하기</string>
-    <string name="insta_content_msg">방금 업로드한 멋진 인증,\n더 많은 친구들에게 자랑해 볼까요?</string>
     <string name="insta_cancel_msg"><u>피드로 보러 가기</u></string>
+    <string name="insta_left_day_title">DAY %d</string>
+    <string name="insta_left_day_1_content">일단 시작했으니 반은 성공!\n자, 더 많은 친구들에게 자랑해 볼까요?</string>
+    <string name="insta_left_day_3_content">우와!! 아주 잘하고 있어요!\n이대로 일주일까지 쭉~ 달려봐요!</string>
+    <string name="insta_left_day_7_content">서로의 도움이 중요한 시기예요!\n앞으로 스파크 마구 보내기로 약-속!</string>
+    <string name="insta_left_day_33_content">이제 반도 안 남았으니,\n점점 습관으로 자리잡고 있겠는 걸요?</string>
+    <string name="insta_left_day_59_content">일주일도 안 남았네요!\n거의 다 왔는 걸요? 조금만 더 Fighting!</string>
+    <string name="insta_left_day_66_content">드디어 인증이 끝났군요! 짝짝짝\n66일 간의 멋진 도전에 박수를 보내요!</string>
+
 
     <!-- InstaActivity -->
     <string name="insta_error_msg">공유할 수 있는 앱이 없습니다.</string>


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closes #350 
## 💻화면 이름
    #350 인증완료 다이얼로그
## 완료 태스크
    - 날짜별 멘트 분기처리
    - 다이얼로그 자체 마진 수정