### PR TITLE
#353 [전체] 수정작업

### DIFF
--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -107,12 +107,17 @@ class SparkMessagingService : FirebaseMessagingService() {
     private fun getChannelId(category: String) =
         getSummaryId(category).toString() + getString(R.string.app_name)
 
-    private fun getSummary(category: String) =
-        NotificationCompat.Builder(this, getChannelId(category))
+    private fun getSummary(category: String): NotificationCompat.Builder {
+        val intent = Intent(this, IntroActivity::class.java)
+        val pendingIntent =
+            PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        return NotificationCompat.Builder(this, getChannelId(category))
             .setSmallIcon(R.mipmap.ic_app_logo)
             .setContentTitle(getString(R.string.app_name))
+            .setContentIntent(pendingIntent)
             .setGroup(category)
             .setGroupSummary(true)
+    }
 
     private fun getSummaryId(category: String) = when (category) {
         CATEGORY_CERTIFICATION.groupName -> CATEGORY_CERTIFICATION.summaryId

--- a/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
+++ b/app/src/main/java/com/spark/android/ui/share/InstaShareDialogFragment.kt
@@ -25,7 +25,7 @@ class InstaShareDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.leftDay = arguments?.getInt("leftDay") ?: -1
+        binding.day = 66 - (arguments?.getInt("leftDay") ?: -1)
         setConfirmTextClickListener()
         setCancelTextClickListener()
     }

--- a/app/src/main/java/com/spark/android/util/BindingAdapters.kt
+++ b/app/src/main/java/com/spark/android/util/BindingAdapters.kt
@@ -540,9 +540,9 @@ object BindingAdapters {
 
     @JvmStatic
     @BindingAdapter("setShareDialogContent")
-    fun TextView.setShareDialogContent(leftDay: Int) {
+    fun TextView.setShareDialogContent(day: Int) {
         this.setText(
-            when (leftDay) {
+            when (day) {
                 in 1..2 -> R.string.insta_left_day_1_content
                 in 3..6 -> R.string.insta_left_day_3_content
                 in 7..32 -> R.string.insta_left_day_7_content

--- a/app/src/main/java/com/spark/android/util/BindingAdapters.kt
+++ b/app/src/main/java/com/spark/android/util/BindingAdapters.kt
@@ -494,22 +494,22 @@ object BindingAdapters {
             "DONE" -> {
                 Glide.with(this.context)
                     .load(url)
-                    .placeholder(R.color.spark_light_gray)
-                    .error(R.color.spark_light_gray)
+                    .placeholder(R.color.spark_dark_gray)
+                    .error(R.color.spark_dark_gray)
                     .into(this)
             }
             "REST" -> {
                 Glide.with(this.context)
                     .load(R.drawable.ic_photo_collection_sticker_rest)
-                    .placeholder(R.color.spark_light_gray)
-                    .error(R.color.spark_light_gray)
+                    .placeholder(R.color.spark_dark_gray)
+                    .error(R.color.spark_dark_gray)
                     .into(this)
             }
             "NONE" -> {
                 Glide.with(this.context)
                     .load(R.drawable.ic_photo_collection_sticker_none)
-                    .placeholder(R.color.spark_light_gray)
-                    .error(R.color.spark_light_gray)
+                    .placeholder(R.color.spark_dark_gray)
+                    .error(R.color.spark_dark_gray)
                     .into(this)
             }
             "CONSIDER" -> {

--- a/app/src/main/res/drawable/ic_check_box_unchecked.xml
+++ b/app/src/main/res/drawable/ic_check_box_unchecked.xml
@@ -4,7 +4,8 @@
     android:viewportWidth="20"
     android:viewportHeight="20">
   <path
-      android:pathData="M2,0C0.8954,0 0,0.8954 0,2V18C0,19.1046 0.8954,20 2,20H18C19.1046,20 20,19.1046 20,18V2C20,0.8954 19.1046,0 18,0H2ZM8.3176,15.5648L16.106,7.1773L15.0068,6.1566L8.3507,13.3247L5.0097,9.5064L3.8809,10.4942L8.3176,15.5648Z"
-      android:fillColor="#EDEDEE"
-      android:fillType="evenOdd"/>
+      android:strokeWidth="1"
+      android:pathData="M2,0.5L18,0.5A1.5,1.5 0,0 1,19.5 2L19.5,18A1.5,1.5 0,0 1,18 19.5L2,19.5A1.5,1.5 0,0 1,0.5 18L0.5,2A1.5,1.5 0,0 1,2 0.5z"
+      android:fillColor="#00000000"
+      android:strokeColor="#B1B2B4"/>
 </vector>

--- a/app/src/main/res/layout/dialog_insta_share.xml
+++ b/app/src/main/res/layout/dialog_insta_share.xml
@@ -5,7 +5,7 @@
     <data>
 
         <variable
-            name="leftDay"
+            name="day"
             type="Integer" />
     </data>
 
@@ -42,7 +42,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:fontFamily="@font/futura_medium_italic"
-            android:text="@{@string/insta_left_day_title(leftDay)}"
+            android:text="@{@string/insta_left_day_title(day)}"
             android:textColor="@color/spark_dark_pinkred"
             android:textSize="24dp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -51,7 +51,7 @@
 
         <TextView
             android:id="@+id/tv_insta_content"
-            setShareDialogContent="@{leftDay}"
+            setShareDialogContent="@{day}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closes #353 
## 💻화면 이름
    #353 푸쉬알림, 회원탈퇴, 보관함, 인증완료다이얼로그
## 완료 태스크
    - 푸쉬알림 그룹 클릭 시에도 앱 실행하도록 수정
    - 회원탈퇴 체크박스 에셋 수정
    - 보관함 플레이스홀더 색상 수정
    - 인증완료다이얼로그 타이틀, 내용 분기처리 기준 leftDay가 아닌 진행한 날 수로 수정