### PR TITLE
#385 [푸쉬알림] 인증완료 이미지 리사이징해서 받아오던 것 업로드하던 사이즈 그대로 받아오도록 수정

### DIFF
--- a/app/src/main/java/com/spark/android/SparkMessagingService.kt
+++ b/app/src/main/java/com/spark/android/SparkMessagingService.kt
@@ -6,17 +6,12 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import android.util.Log
 import androidx.core.app.NotificationCompat
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.target.CustomTarget
-import com.bumptech.glide.request.transition.Transition
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.spark.android.ui.intro.IntroActivity
 import com.spark.android.util.ImageCropUtil
-import com.spark.android.util.ImageUrlTransformer
 import com.spark.android.util.useBitmapImg
 import java.lang.IllegalArgumentException
 
@@ -92,7 +87,7 @@ class SparkMessagingService : FirebaseMessagingService() {
 
     private fun transformImageUrlToBitmap(remoteMessage: RemoteMessage) {
         val imageUrl = remoteMessage.data["imageUrl"].toString()
-        useBitmapImg(this, ImageUrlTransformer.getSmallSizeImageUrl(imageUrl)) { bitmap ->
+        useBitmapImg(this, imageUrl) { bitmap ->
             createNotificationWithImage(
                 remoteMessage,
                 if (bitmap.width != bitmap.height) {


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closes #385 
## 💻화면 이름
    #385 푸쉬알림
## 완료 태스크
    - 인증완료 이미지 리사이징해서 받아오던 것 업로드하던 사이즈 그대로 받아오도록 수정
