### PR TITLE
#450 [알림 센터] 레이아웃 및 스와이프 재설정 

### DIFF
--- a/app/src/main/java/com/spark/android/ui/alarmcenter/AlarmCenterActivity.kt
+++ b/app/src/main/java/com/spark/android/ui/alarmcenter/AlarmCenterActivity.kt
@@ -46,6 +46,7 @@ class AlarmCenterActivity :
 
     private fun initVpAlarmCenterAdapter() {
         binding.vpAlarmCenter.apply {
+            isUserInputEnabled = false
             adapter = object : FragmentStateAdapter(this@AlarmCenterActivity) {
                 override fun getItemCount() = VP_ITEM_COUNT
 

--- a/app/src/main/res/layout/item_alarm_list.xml
+++ b/app/src/main/res/layout/item_alarm_list.xml
@@ -22,7 +22,7 @@
             android:id="@+id/view_alarm_list_top"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="@color/spark_gray"
+            android:background="@color/spark_gray_opacity_30"
             android:visibility="@{alarm.isFirst? View.GONE : View.VISIBLE}"
             app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closed #450

## 💻화면 이름
#450 알림센터

## 완료 태스크
- 구분선 색상 : spark_gray, opacity 30%
- 스와이프로 탭 전환 막기

