### PR TITLE
#495 [카메라] 카메라 사용 시 에러 해결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-feature
         android:name="android.hardware.camera2"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,11 +84,13 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".ui.habit.HabitActivity"
+            android:configChanges="orientation"
             android:exported="true"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustNothing" />
         <activity
             android:name=".ui.auth.AuthActivity"
+            android:configChanges="orientation"
             android:exported="true"
             android:screenOrientation="portrait" />
         <activity

--- a/app/src/main/java/com/spark/android/ui/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/spark/android/ui/feed/FeedViewModel.kt
@@ -9,8 +9,6 @@ import com.spark.android.data.remote.entity.response.FeedListItem
 import com.spark.android.data.remote.repository.FeedRepository
 import com.spark.android.ui.feed.adapter.FeedAdapter.Companion.FEED_FOOTER_TYPE
 import com.spark.android.ui.feed.adapter.FeedAdapter.Companion.FEED_LOADING_TYPE
-import com.spark.android.util.FirebaseLogUtil
-import com.spark.android.util.FirebaseLogUtil.CLICK_HEART_FEED
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -58,7 +56,6 @@ class FeedViewModel @Inject constructor(
     }
 
     fun postFeedHeart(feedListItem: FeedListItem) {
-        FirebaseLogUtil.logClickEvent(CLICK_HEART_FEED)
         viewModelScope.launch {
             val feed = requireNotNull(feedListItem.feed)
             feedRepository.postFeedHeart(feed.recordId)

--- a/app/src/main/java/com/spark/android/ui/feed/adapter/FeedAdapter.kt
+++ b/app/src/main/java/com/spark/android/ui/feed/adapter/FeedAdapter.kt
@@ -14,6 +14,8 @@ import com.spark.android.databinding.ItemFeedContentBinding
 import com.spark.android.databinding.ItemFeedFooterBinding
 import com.spark.android.databinding.ItemFeedHeaderBinding
 import com.spark.android.databinding.ItemFeedLoadingBinding
+import com.spark.android.util.FirebaseLogUtil
+import com.spark.android.util.FirebaseLogUtil.CLICK_HEART_FEED
 import java.lang.IllegalStateException
 
 class FeedAdapter(
@@ -67,6 +69,7 @@ class FeedAdapter(
                             }
                         }
                         false -> {
+                            FirebaseLogUtil.logClickEvent(CLICK_HEART_FEED)
                             binding.btnFeedHeart.setImageResource(R.drawable.ic_feed_heart_pink)
                             binding.tvFeedHeartCount.let {
                                 it.setTextColor(it.context.getColor(R.color.spark_pinkred))

--- a/app/src/main/java/com/spark/android/util/ImageProvider.kt
+++ b/app/src/main/java/com/spark/android/util/ImageProvider.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import com.bumptech.glide.Glide
@@ -19,10 +20,13 @@ fun getImgUri(contentResolver: ContentResolver): Uri? {
     val folderName = "Spark"
     val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss").format(Date())
     val picturePath = "${Environment.DIRECTORY_PICTURES}${File.separator}$folderName"
-    val contentValues = ContentValues()
-    contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, "$timeStamp.jpeg")
-    contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-    contentValues.put(MediaStore.MediaColumns.RELATIVE_PATH, picturePath)
+    val contentValues = ContentValues().apply {
+        put(MediaStore.MediaColumns.DISPLAY_NAME, "$timeStamp.jpeg")
+        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            put(MediaStore.MediaColumns.RELATIVE_PATH, picturePath)
+        }
+    }
 
     return contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
 }


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closed #495
## 💻화면 이름
#495 카메라 사용
## 완료 태스크
- Android Q 미만의 디바이스에서 카메라 권한 외에 WRITE_EXTERNAL_STORAGE 권한 함께 요청 후 카메라 실행
- 카메라 촬영 실행하는 Activity에 android:configChanges="orientation" 속성 추가하여 화면 회전시에 Activity 재시작하지 않도록 설정