### PR TITLE
#498 [fix] 카메라 사용 중 뒤로가기로 돌아올 때 원래 화면에 머무르도록 하기

### DIFF
--- a/app/src/main/java/com/spark/android/ui/auth/profile/ProfileBottomSheet.kt
+++ b/app/src/main/java/com/spark/android/ui/auth/profile/ProfileBottomSheet.kt
@@ -26,6 +26,8 @@ import com.spark.android.ui.auth.profile.ProfileFragment.Companion.REQUEST_PROFI
 import com.spark.android.ui.auth.profile.ProfileFragment.Companion.REQUEST_PROFILE_IMG_FROM_ALBUM
 import com.spark.android.ui.auth.profile.ProfileFragment.Companion.REQUEST_PROFILE_IMG_FROM_CAMERA
 import com.spark.android.util.getImgUri
+import com.spark.android.util.getPathFromUri
+import java.io.File
 import java.lang.NullPointerException
 
 class ProfileBottomSheet : BottomSheetDialogFragment() {
@@ -62,7 +64,9 @@ class ProfileBottomSheet : BottomSheetDialogFragment() {
     private val fromCameraActivityLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {
-        setFragmentResult(REQUEST_PROFILE_IMG_FROM_CAMERA, bundleOf(PROFILE_IMG to imgUri))
+        if (File(getPathFromUri(requireContext(), imgUri)).exists()) {
+            setFragmentResult(REQUEST_PROFILE_IMG_FROM_CAMERA, bundleOf(PROFILE_IMG to imgUri))
+        }
         dismiss()
     }
 

--- a/app/src/main/java/com/spark/android/ui/certify/CertifyBottomSheet.kt
+++ b/app/src/main/java/com/spark/android/ui/certify/CertifyBottomSheet.kt
@@ -24,6 +24,8 @@ import com.spark.android.ui.certify.viewmodel.CertifyViewModel
 import android.util.Log
 import com.spark.android.ui.auth.profile.ProfileBottomSheet.Companion.REQUEST_CAMERA_PERMISSION_UNDER_Q
 import com.spark.android.util.getImgUri
+import com.spark.android.util.getPathFromUri
+import java.io.File
 import java.lang.NullPointerException
 
 class CertifyBottomSheet : BottomSheetDialogFragment() {
@@ -62,8 +64,10 @@ class CertifyBottomSheet : BottomSheetDialogFragment() {
     private val fromCameraActivityLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {
-        certifyViewModel.initImgUri(imgUri)
-        showCertifyActivity()
+        if (File(getPathFromUri(requireContext(), imgUri)).exists()) {
+            certifyViewModel.initImgUri(imgUri)
+            showCertifyActivity()
+        }
         dismiss()
     }
 

--- a/app/src/main/java/com/spark/android/util/ImageProvider.kt
+++ b/app/src/main/java/com/spark/android/util/ImageProvider.kt
@@ -3,6 +3,7 @@ package com.spark.android.util
 import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
+import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -13,6 +14,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import java.io.File
+import java.lang.NullPointerException
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -45,4 +47,18 @@ fun useBitmapImg(context: Context, imgUrl: String, useBitmap: (Bitmap) -> Unit) 
 
             override fun onLoadCleared(placeholder: Drawable?) {}
         })
+}
+
+fun getPathFromUri(context: Context, uri: Uri): String {
+    val cursor: Cursor = context.contentResolver.query(uri, null, null, null, null)
+        ?: throw NullPointerException()
+    cursor.moveToNext()
+    val columnIndex = cursor.getColumnIndex("_data")
+    val path = if (columnIndex >= 0) {
+        cursor.getString(columnIndex)
+    } else {
+        throw IllegalAccessException()
+    }
+    cursor.close()
+    return path
 }


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closed #498
## 💻화면 이름
#498 카메라
## 완료 태스크
- 카메라 사용 중 뒤로갔을 경우 해당 uri에 파일이 존재하지 않을 것이므로 파일 존재 유무 확인 후 파일이 없을 경우 이전 화면으로 가도록 구현
