### PR TITLE
#502 [fix] 피드 신고하기 화면에서 시스템 뒤로가기 버튼 클릭 시 피드에 머무를 수 있도록 수정

### DIFF
--- a/app/src/main/java/com/spark/android/ui/feedreport/FeedReportActivity.kt
+++ b/app/src/main/java/com/spark/android/ui/feedreport/FeedReportActivity.kt
@@ -26,6 +26,15 @@ class FeedReportActivity : BaseActivity<ActivityFeedReportBinding>(R.layout.acti
         initBackBtnClickListener()
     }
 
+    override fun onBackPressed() {
+        super.onBackPressed()
+        startActivity(Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK and Intent.FLAG_ACTIVITY_CLEAR_TASK
+            putExtra(MainActivity.FROM_WHERE, FROM_FEED_REPORT_ACTIVITY)
+        })
+        finish()
+    }
+
     private fun initFeedItemId() {
         feedReportViewModel.initFeedItemId(intent.getIntExtra(FEED_ITEM_ID, -1))
     }


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closed #502
## 💻화면 이름
#502 신고하기
## 완료 태스크
- 피드 신고하기 화면에서 시스템 뒤로가기 버튼 클릭 시 피드에 머무를 수 있도록 수정

