### PR TITLE
#527 [프로필 및 카메라] 프로필 입력/수정 화면에서의 시스템 뒤로가기 이벤트처리 및 카메라 권한 체크 변수에서 함수로 변경

### DIFF
--- a/app/src/main/java/com/spark/android/ui/auth/profile/ProfileBottomSheet.kt
+++ b/app/src/main/java/com/spark/android/ui/auth/profile/ProfileBottomSheet.kt
@@ -34,20 +34,6 @@ class ProfileBottomSheet : BottomSheetDialogFragment() {
     private var _binding: BottomSheetProfileBinding? = null
     val binding get() = _binding ?: error(getString(R.string.binding_error))
 
-    private val checkCameraPermission by lazy {
-        ContextCompat.checkSelfPermission(
-            requireContext(),
-            android.Manifest.permission.CAMERA
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-
-    private val checkCameraPermissionUnderQ by lazy {
-        checkCameraPermission && ContextCompat.checkSelfPermission(
-            requireContext(),
-            android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-
     private lateinit var imgUri: Uri
 
     private val fromAlbumActivityLauncher = registerForActivityResult(
@@ -69,7 +55,6 @@ class ProfileBottomSheet : BottomSheetDialogFragment() {
         }
         dismiss()
     }
-
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -122,7 +107,7 @@ class ProfileBottomSheet : BottomSheetDialogFragment() {
     private fun initFromCameraBtnClickListener() {
         binding.tvProfileBottomFromCamera.setOnClickListener {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                if (checkCameraPermission) {
+                if (checkCameraPermission()) {
                     takePicture()
                 } else {
                     ActivityCompat.requestPermissions(
@@ -132,7 +117,7 @@ class ProfileBottomSheet : BottomSheetDialogFragment() {
                     )
                 }
             } else {
-                if (checkCameraPermissionUnderQ) {
+                if (checkCameraPermissionUnderQ()) {
                     takePicture()
                 } else {
                     ActivityCompat.requestPermissions(
@@ -147,6 +132,19 @@ class ProfileBottomSheet : BottomSheetDialogFragment() {
             }
         }
     }
+
+    private fun checkCameraPermission() =
+        ContextCompat.checkSelfPermission(
+            requireContext(),
+            android.Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+
+
+    private fun checkCameraPermissionUnderQ() =
+        checkCameraPermission() && ContextCompat.checkSelfPermission(
+            requireContext(),
+            android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+        ) == PackageManager.PERMISSION_GRANTED
 
     private fun takePicture() {
         try {

--- a/app/src/main/java/com/spark/android/ui/auth/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/spark/android/ui/auth/profile/ProfileFragment.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
@@ -47,6 +48,7 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(R.layout.fragment_p
         initLayoutClickListener()
         initIsFocused()
         initQuitBtnClickListener()
+        initOnBackPressed()
         initPictureBtnClickListener()
         initSuccessSignUpObserver()
         initOldProfileImgUrlObserver()
@@ -91,14 +93,27 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(R.layout.fragment_p
         }
     }
 
+    private fun showDialog() {
+        DialogUtil(
+            if (args.modifyMode) STOP_MODIFY_PROFILE else STOP_SIGNUP_MODE
+        ) {
+            popBackStack()
+        }.show(parentFragmentManager, this.javaClass.name)
+    }
+
     private fun initQuitBtnClickListener() {
         binding.btnProfileQuit.setOnClickListener {
-            DialogUtil(
-                if (args.modifyMode) STOP_MODIFY_PROFILE else STOP_SIGNUP_MODE
-            ) {
-                popBackStack()
-            }.show(parentFragmentManager, this.javaClass.name)
+            showDialog()
         }
+    }
+
+    private fun initOnBackPressed() {
+        requireActivity().onBackPressedDispatcher
+            .addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    showDialog()
+                }
+            })
     }
 
     private fun initSuccessSignUpObserver() {

--- a/app/src/main/java/com/spark/android/ui/certify/CertifyBottomSheet.kt
+++ b/app/src/main/java/com/spark/android/ui/certify/CertifyBottomSheet.kt
@@ -35,20 +35,6 @@ class CertifyBottomSheet : BottomSheetDialogFragment() {
     private lateinit var imgUri: Uri
     private val certifyViewModel by activityViewModels<CertifyViewModel>()
 
-    private val checkCameraPermission by lazy {
-        ContextCompat.checkSelfPermission(
-            requireContext(),
-            android.Manifest.permission.CAMERA
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-
-    private val checkCameraPermissionUnderQ by lazy {
-        checkCameraPermission && ContextCompat.checkSelfPermission(
-            requireContext(),
-            android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-
     private val fromAlbumActivityLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result: ActivityResult ->
@@ -132,7 +118,7 @@ class CertifyBottomSheet : BottomSheetDialogFragment() {
     private fun initFromCameraBtnClickListener() {
         binding.tvCertifyCamera.setOnClickListener {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                if (checkCameraPermission) {
+                if (checkCameraPermission()) {
                     takePicture()
                 } else {
                     ActivityCompat.requestPermissions(
@@ -142,7 +128,7 @@ class CertifyBottomSheet : BottomSheetDialogFragment() {
                     )
                 }
             } else {
-                if (checkCameraPermissionUnderQ) {
+                if (checkCameraPermissionUnderQ()) {
                     takePicture()
                 } else {
                     ActivityCompat.requestPermissions(
@@ -157,6 +143,19 @@ class CertifyBottomSheet : BottomSheetDialogFragment() {
             }
         }
     }
+
+    private fun checkCameraPermission() =
+        ContextCompat.checkSelfPermission(
+            requireContext(),
+            android.Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+
+
+    private fun checkCameraPermissionUnderQ() =
+        checkCameraPermission() && ContextCompat.checkSelfPermission(
+            requireContext(),
+            android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+        ) == PackageManager.PERMISSION_GRANTED
 
     private fun takePicture() {
         try {


### PR DESCRIPTION
## ✒️관련 이슈번호
- Closed #527
## 💻화면 이름
#527 프로필 및 카메라 
## 완료 태스크
- 카메라 권한 체크 변수에서 함수로 변경
- 프로필 입력/수정 화면에서 시스템 뒤로가기 이벤트 발생 시에도 다이얼로그 띄우기

